### PR TITLE
Add SEO/OG tags, blog search, and Vercel Analytics

### DIFF
--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -4,6 +4,9 @@ import Footer from '../sections/Footer'
 import { useRouter } from 'next/router'
 import config from '../../lib/config';
 
+const twitterHandle = '@' + config.social.twitter.split('/').pop();
+const defaultOgImage = `${config.siteUrl}/profile.jpeg`;
+
 const Layout = ({ children, pageMeta }) => {
 
   const router = useRouter();
@@ -11,28 +14,41 @@ const Layout = ({ children, pageMeta }) => {
   const meta = {
     title: config.siteName,
     description: config.siteDescription,
+    image: defaultOgImage,
     type: 'website',
     ...pageMeta,
   };
 
+  const canonicalUrl = `${config.siteUrl}${router.asPath}`;
 
   return (
     <>
       <Head>
         <title>{meta.title}</title>
-        <meta name="description" content={meta.description}></meta>
-        <link rel="icon" href='/favicon.ico'></link>
+        <meta name="description" content={meta.description} />
+        <link rel="canonical" href={canonicalUrl} />
+        <link rel="icon" href='/favicon.ico' />
+
         {/* Open Graph */}
-        <meta property='og:url' content={`${config.siteUrl}${router.asPath}`}/>
-        <meta property='og:type' content={meta.type}/>
-        <meta property='og:site_name' content={config.siteName}/>
-        <meta property='og:description' content={meta.description}/>
-        <meta property='og:title' content={meta.title}/>
-        {meta.date && (
-          <meta property='article:published_time' content={meta.date} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:type" content={meta.type} />
+        <meta property="og:site_name" content={config.siteName} />
+        <meta property="og:title" content={meta.title} />
+        <meta property="og:description" content={meta.description} />
+        <meta property="og:image" content={meta.image} />
+        {meta.type === 'article' && meta.date && (
+          <meta property="article:published_time" content={meta.date} />
         )}
+
+        {/* Twitter Card */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content={twitterHandle} />
+        <meta name="twitter:creator" content={twitterHandle} />
+        <meta name="twitter:title" content={meta.title} />
+        <meta name="twitter:description" content={meta.description} />
+        <meta name="twitter:image" content={meta.image} />
       </Head>
-      
+
       <div className='min-h-screen flex flex-col'>
         <Header />
         <main className='flex-grow container mx-auto px-4 sm:px-6'>{children}</main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@mdx-js/react": "^2.3.0",
         "@next/mdx": "^13.2.4",
         "@tailwindcss/typography": "^0.5.9",
+        "@vercel/analytics": "^2.0.1",
         "date-fns": "^2.29.3",
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.11.1",
@@ -1237,6 +1238,48 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@mdx-js/react": "^2.3.0",
     "@next/mdx": "^13.2.4",
     "@tailwindcss/typography": "^0.5.9",
+    "@vercel/analytics": "^2.0.1",
     "date-fns": "^2.29.3",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.11.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,12 @@
 import '../styles/globals.css';
 import { ThemeProvider } from 'next-themes';
+import { Analytics } from '@vercel/analytics/react';
 
 export default function App({ Component, pageProps }) {
     return (
         <ThemeProvider enableSystem={true} attribute='class'>
             <Component {...pageProps} />
+            <Analytics />
         </ThemeProvider>
     );
 }

--- a/pages/blog/[id].js
+++ b/pages/blog/[id].js
@@ -30,6 +30,8 @@ export default function Blog({ postData }) {
     const pageMeta = {
       type: 'article',
       title: postData.title,
+      description: postData.excerpt || postData.title,
+      date: postData.date,
     }
 
     return (

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,40 +1,85 @@
-import Card from '../../components/card/card'
+import { useState } from 'react';
+import Card from '../../components/card/card';
 import Layout from '../../components/layout/layout';
 import { getSortedPostsData } from '../../lib/posts';
+import config from '../../lib/config';
 
 export async function getStaticProps() {
-
   try {
     const allPostsData = await getSortedPostsData();
-
-    return {
-      props: {
-        allPostsData,
-      },
-    };
-  } catch(error) {
-    return {
-      props: {
-        allPostsData: []
-      }
-    }
+    return { props: { allPostsData } };
+  } catch (error) {
+    return { props: { allPostsData: [] } };
   }
-
 }
 
-export default function Blog ({ allPostsData }) {
+export default function Blog({ allPostsData }) {
+  const [query, setQuery] = useState('');
+
+  const filtered = query.trim()
+    ? allPostsData.filter(
+        (post) =>
+          post.title?.toLowerCase().includes(query.toLowerCase()) ||
+          post.excerpt?.toLowerCase().includes(query.toLowerCase())
+      )
+    : allPostsData;
+
   return (
-      <Layout>
-          <section className='text-center pt-12 sm:pt-24 pb-16'>
-            <h1 className='text-4xl sm:text-7xl font-bold capitalize'>
-              Blog Posts
-            </h1>
-          </section>
+    <Layout
+      pageMeta={{
+        title: `Blog – ${config.siteName}`,
+        description: 'Articles on Azure, DevOps, Kubernetes, Docker, and cloud-native engineering.',
+      }}
+    >
+      <section className="text-center pt-12 sm:pt-24 pb-10">
+        <h1 className="text-4xl sm:text-7xl font-bold capitalize mb-8">Blog Posts</h1>
 
-          <div className='grid grid-cols-1 gap-6 sm:gap-8 max-w-screen-lg mx-auto pb-8'>
-            {allPostsData.map(post => <Card key={post.id} {...post} />)}
-          </div>
-      </Layout>
+        {/* Search */}
+        <div className="relative max-w-lg mx-auto">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search posts…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full pl-10 pr-10 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
+          />
+          {query && (
+            <button
+              onClick={() => setQuery('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              aria-label="Clear search"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {query && (
+          <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+            {filtered.length} result{filtered.length !== 1 ? 's' : ''} for &ldquo;{query}&rdquo;
+          </p>
+        )}
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 sm:gap-8 max-w-screen-lg mx-auto pb-16">
+        {filtered.length > 0 ? (
+          filtered.map((post) => <Card key={post.id} {...post} />)
+        ) : (
+          <p className="text-center text-gray-500 dark:text-gray-400 py-12">
+            No posts match &ldquo;{query}&rdquo;
+          </p>
+        )}
+      </div>
+    </Layout>
   );
-};
-
+}


### PR DESCRIPTION
## Summary

### SEO / Open Graph
- Every page now has a complete set of `og:` and `twitter:` meta tags
- `og:image` defaults to your profile photo (`/profile.jpeg`) so shares on LinkedIn/X always show a face, not a blank card
- Blog posts pass their `excerpt` as `og:description` and `date` as `article:published_time`
- Added `<link rel="canonical">` to every page

### Blog search
- Search bar on `/blog` filters posts instantly by title or excerpt
- Shows result count while a query is active (e.g. "3 results for "docker"")
- Clear (✕) button to reset the search

### Vercel Analytics
- `@vercel/analytics` wired into `_app.js` — page views and Web Vitals will start appearing in your Vercel dashboard immediately after deploy (no extra config needed)

## Test plan

- [ ] Share a blog post URL on LinkedIn/Slack — verify the post title, excerpt, and profile photo appear in the preview card
- [ ] Visit `/blog`, type a keyword — confirm posts filter correctly and result count updates
- [ ] Check Vercel dashboard → Analytics tab after deploying — page views should appear

https://claude.ai/code/session_01DUbdRnLfwF6aEcGrxTxFZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUbdRnLfwF6aEcGrxTxFZX)_