### PR TITLE
Add reading time, TOC, social share, and contact page

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -9,10 +9,14 @@ export default function Card(props) {
           {props?.title || 'Untitled'}
         </h3>
 
-        <div className="text-sm mb-3">
-          <small className="text-gray-500">
-            <Date dateString={props.date} />
-          </small>
+        <div className="flex items-center gap-2 text-sm mb-3 text-gray-500">
+          <Date dateString={props.date} />
+          {props.readingTime && (
+            <>
+              <span>·</span>
+              <span>{props.readingTime} min read</span>
+            </>
+          )}
         </div>
 
         <p className="text-gray-500 dark:text-gray-400 text-sm flex-1 line-clamp-2">

--- a/components/sections/Header.js
+++ b/components/sections/Header.js
@@ -10,6 +10,7 @@ const navLinks = [
   { href: '/blog', label: 'Blog' },
   { href: '/videos', label: 'Videos' },
   { href: '/speaking', label: 'Speaking' },
+  { href: '/contact', label: 'Contact' },
 ];
 
 const Header = () => {

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ const config = {
   authorBio:
     'Cloud Solution Architect with 12+ years of experience designing scalable enterprise platforms on Azure. Mechanical engineer by degree, software architect by profession.',
   location: 'Mumbai, India',
+  contactEmail: 'ashish.sbaghel@outlook.com',
   social: {
     github: 'https://github.com/mechdeveloper',
     linkedin: 'https://www.linkedin.com/in/baghelashish',

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -15,19 +15,20 @@ function readingTime(content) {
 }
 
 function slugify(text) {
+  // Match github-slugger (used by rehype-slug) exactly:
+  // replace spaces with hyphens, then strip everything that isn't word char or hyphen.
+  // Do NOT collapse multiple hyphens — "| .ext" → "--ext" is intentional.
   return text
     .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^\w-]/g, '')
-    .replace(/--+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/ /g, '-')
+    .replace(/[^\w-]/g, '');
 }
 
 function cleanHeadingText(raw) {
   return raw
     .trim()
-    .replace(/\\(.)/g, '$1')   // unescape markdown escapes: \. → .
-    .replace(/[*_`[\]()]/g, '') // strip inline formatting chars
+    .replace(/\\(.)/g, '$1')  // unescape markdown escapes: \. → .
+    .replace(/[*_`[\]]/g, '') // strip bold/italic/code/link syntax; keep ( ) | .
     .trim();
 }
 

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -8,11 +8,36 @@ import rehypeHighlight from "rehype-highlight";
 
 const postsDirectory = path.join(process.cwd(), 'posts');
 
+function readingTime(content) {
+  const text = content.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
+  const words = text.trim().split(/\s+/).length;
+  return Math.max(1, Math.ceil(words / 200));
+}
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w-]/g, '')
+    .replace(/--+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function extractHeadings(content) {
+  const headingRegex = /^(#{2,3})\s+(.+)$/gm;
+  const headings = [];
+  let match;
+  while ((match = headingRegex.exec(content)) !== null) {
+    const level = match[1].length;
+    const text = match[2].trim().replace(/\*\*|__|\*|_|`/g, '');
+    headings.push({ level, text, slug: slugify(text) });
+  }
+  return headings;
+}
+
 export async function getPostData(id) {
   const fullPath = path.join(postsDirectory, `${id}/index.mdx`);
   const fileContents = fs.readFileSync(fullPath, 'utf8');
-
-  // Use gray-matter to parse the post metadata section
   const matterResult = matter(fileContents);
 
   const mdxSource = await serialize(matterResult.content, {
@@ -22,73 +47,42 @@ export async function getPostData(id) {
     },
   });
 
-
-  // Combine the data with the id and contentHtml
   return {
     id,
     mdxSource,
+    readingTime: readingTime(matterResult.content),
+    headings: extractHeadings(matterResult.content),
     ...matterResult.data,
   };
 }
 
 export function getSortedPostsData() {
-  // Get file names under /posts
   const fileNames = fs.readdirSync(postsDirectory);
 
   const allPostsData = fileNames.map((fileName) => {
-    // Remove ".mdx" from file name to get id
     const id = fileName.replace(/\.mdx$/, '');
-    
+
     if (fs.lstatSync(path.join(postsDirectory, fileName)).isDirectory()) {
-      fileName = fileName + '/index.mdx'
+      fileName = fileName + '/index.mdx';
     }
 
-    // Read markdown file as string
     const fullPath = path.join(postsDirectory, fileName);
     const fileContents = fs.readFileSync(fullPath, 'utf8');
-
-    // Use gray-matter to parse the post metadata section
     const matterResult = matter(fileContents);
 
-    // Combine the data with the id
     return {
       id,
+      readingTime: readingTime(matterResult.content),
       ...matterResult.data,
     };
   });
 
-  // Sort posts by date
-  return allPostsData.sort((a, b) => {
-    if (a.date < b.date) {
-      return 1;
-    } else {
-      return -1;
-    }
-  });
+  return allPostsData.sort((a, b) => (a.date < b.date ? 1 : -1));
 }
 
 export function getAllPostIds() {
-    const fileNames = fs.readdirSync(postsDirectory);
-  
-    // Returns an array that looks like this:
-    // [
-    //   {
-    //     params: {
-    //       id: 'ssg-ssr'
-    //     }
-    //   },
-    //   {
-    //     params: {
-    //       id: 'pre-rendering'
-    //     }
-    //   }
-    // ]
-    return fileNames.map((fileName) => {
-      return {
-        params: {
-          id: fileName.replace(/\.mdx$/, ''),
-        },
-      };
-    });
+  const fileNames = fs.readdirSync(postsDirectory);
+  return fileNames.map((fileName) => ({
+    params: { id: fileName.replace(/\.mdx$/, '') },
+  }));
 }
-

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -23,14 +23,45 @@ function slugify(text) {
     .replace(/^-+|-+$/g, '');
 }
 
+function cleanHeadingText(raw) {
+  return raw
+    .trim()
+    .replace(/\\(.)/g, '$1')   // unescape markdown escapes: \. → .
+    .replace(/[*_`[\]()]/g, '') // strip inline formatting chars
+    .trim();
+}
+
 function extractHeadings(content) {
-  const headingRegex = /^(#{2,3})\s+(.+)$/gm;
   const headings = [];
-  let match;
-  while ((match = headingRegex.exec(content)) !== null) {
-    const level = match[1].length;
-    const text = match[2].trim().replace(/\*\*|__|\*|_|`/g, '');
-    headings.push({ level, text, slug: slugify(text) });
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // ATX-style: ## Heading or ### Heading
+    const atxMatch = line.match(/^(#{2,3})\s+(.+?)(?:\s+#+)?$/);
+    if (atxMatch) {
+      const text = cleanHeadingText(atxMatch[2]);
+      if (text) headings.push({ level: atxMatch[1].length, text, slug: slugify(text) });
+      continue;
+    }
+
+    // Setext-style: text line followed by === (h1) or --- (h2) underline
+    if (i + 1 < lines.length) {
+      const nextLine = lines[i + 1].trim();
+      const trimmed = line.trim();
+      if (trimmed.length >= 2 && !trimmed.startsWith('#') && !trimmed.startsWith('>') && !trimmed.startsWith('|')) {
+        if (/^={2,}$/.test(nextLine)) {
+          // H1 — skip, don't include in TOC
+          i++;
+        } else if (/^-{2,}$/.test(nextLine)) {
+          // H2
+          const text = cleanHeadingText(trimmed);
+          if (text) headings.push({ level: 2, text, slug: slugify(text) });
+          i++;
+        }
+      }
+    }
   }
   return headings;
 }

--- a/pages/blog/[id].js
+++ b/pages/blog/[id].js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Image from "next/image";
 import Layout from '../../components/layout/layout';
 import Date from '../../components/date';
@@ -5,51 +6,174 @@ import { getAllPostIds, getPostData } from '../../lib/posts';
 import { MDXRemote } from "next-mdx-remote";
 import YouTube from "../../components/youtube/youtube";
 import "highlight.js/styles/atom-one-dark.css";
+import config from '../../lib/config';
 
 export async function getStaticProps({ params }) {
-    // Add the "await" keyword like this:
-    const postData = await getPostData(params.id);
-  
-    return {
-      props: {
-        postData,
-      },
-    };
-  }
+  const postData = await getPostData(params.id);
+  return { props: { postData } };
+}
 
 export async function getStaticPaths() {
   const paths = await getAllPostIds();
-  return {
-    paths,
-    fallback: false,
-  };
+  return { paths, fallback: false };
 }
 
-export default function Blog({ postData }) {
+function TableOfContents({ headings }) {
+  if (!headings || headings.length < 3) return null;
+  return (
+    <nav aria-label="Table of contents">
+      <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-3">
+        On this page
+      </p>
+      <ul className="space-y-1.5">
+        {headings.map((h) => (
+          <li key={h.slug} style={{ paddingLeft: h.level === 3 ? '0.75rem' : '0' }}>
+            <a
+              href={`#${h.slug}`}
+              className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors line-clamp-2"
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
 
-    const pageMeta = {
-      type: 'article',
-      title: postData.title,
-      description: postData.excerpt || postData.title,
-      date: postData.date,
-    }
+function ShareButtons({ title, id }) {
+  const [copied, setCopied] = useState(false);
+  const postUrl = `${config.siteUrl}/blog/${id}`;
+  const encoded = encodeURIComponent(postUrl);
+  const encodedTitle = encodeURIComponent(title);
+  const twitterHandle = config.social.twitter.split('/').pop();
 
-    return (
-      <Layout pageMeta={pageMeta}>
-        <div className="max-w-screen-lg mx-auto py-12 space-y-16">
-          <header>
-            <h1 className='max-w-screen-md lg:text-6xl md:text-5xl sm: text-4xl'>{postData.title}</h1>
-          </header>
-          <div className='text-gray-500'>
+  const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encoded}`;
+  const twitterUrl = `https://twitter.com/intent/tweet?url=${encoded}&text=${encodedTitle}&via=${twitterHandle}`;
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(postUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="mt-16 pt-8 border-t border-gray-100 dark:border-gray-800">
+      <p className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-4">Share this post</p>
+      <div className="flex flex-wrap gap-3">
+        <a
+          href={linkedinUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-[#0A66C2] hover:bg-[#004182] text-white transition-colors"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+          </svg>
+          LinkedIn
+        </a>
+        <a
+          href={twitterUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-black hover:bg-gray-800 text-white transition-colors"
+        >
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          X / Twitter
+        </a>
+        <button
+          onClick={copyLink}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-500 transition-colors"
+        >
+          {copied ? (
+            <>
+              <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              Copied!
+            </>
+          ) : (
+            <>
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+              Copy link
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function BlogPost({ postData }) {
+  const pageMeta = {
+    type: 'article',
+    title: postData.title,
+    description: postData.excerpt || postData.title,
+    date: postData.date,
+  };
+
+  const hasToc = postData.headings?.length >= 3;
+
+  return (
+    <Layout pageMeta={pageMeta}>
+      <div className="max-w-screen-xl mx-auto py-12 px-0">
+
+        {/* Post header */}
+        <header className="max-w-3xl mb-10">
+          <h1 className="text-3xl sm:text-5xl font-bold leading-tight mb-4">{postData.title}</h1>
+          <div className="flex items-center gap-3 text-gray-500 dark:text-gray-400 text-sm">
             <Date dateString={postData.date} />
+            {postData.readingTime && (
+              <>
+                <span>·</span>
+                <span>{postData.readingTime} min read</span>
+              </>
+            )}
           </div>
-          {/* Author */}
+          {postData.tags?.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-4">
+              {postData.tags.map((tag) => (
+                <span key={tag} className="px-2 py-0.5 text-xs rounded-full bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-100 dark:border-blue-800">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {/* Mobile TOC */}
+        {hasToc && (
+          <details className="xl:hidden mb-8 rounded-lg border border-gray-100 dark:border-gray-800 p-4">
+            <summary className="text-sm font-semibold cursor-pointer select-none">Table of contents</summary>
+            <div className="mt-3">
+              <TableOfContents headings={postData.headings} />
+            </div>
+          </details>
+        )}
+
+        {/* Content + sidebar grid */}
+        <div className={hasToc ? 'xl:grid xl:grid-cols-[1fr_220px] xl:gap-16 xl:items-start' : ''}>
           <main>
-            <article className="min-h-screen prose dark:prose-dark sm:prose-lg lg:prose-xl max-w-none">
+            <article className="prose dark:prose-dark sm:prose-lg max-w-none">
               <MDXRemote {...postData.mdxSource} components={{ YouTube, Image }} />
             </article>
+            <ShareButtons title={postData.title} id={postData.id} />
           </main>
+
+          {/* Desktop TOC sidebar */}
+          {hasToc && (
+            <aside className="hidden xl:block sticky top-24 max-h-[calc(100vh-6rem)] overflow-y-auto">
+              <TableOfContents headings={postData.headings} />
+            </aside>
+          )}
         </div>
-      </Layout> 
-    );
-  }
+
+      </div>
+    </Layout>
+  );
+}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import Layout from '../components/layout/layout';
+import config from '../lib/config';
+
+const FORMSPREE_ENDPOINT = process.env.NEXT_PUBLIC_FORMSPREE_ENDPOINT;
+
+export default function Contact() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const [status, setStatus] = useState('idle'); // idle | submitting | success | error
+
+  const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!FORMSPREE_ENDPOINT) {
+      window.location.href = `mailto:${config.contactEmail}?subject=Hello from techhackswithash.com&body=${encodeURIComponent(form.message)}`;
+      return;
+    }
+    setStatus('submitting');
+    try {
+      const res = await fetch(FORMSPREE_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(form),
+      });
+      setStatus(res.ok ? 'success' : 'error');
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  return (
+    <Layout
+      pageMeta={{
+        title: `Contact – ${config.siteName}`,
+        description: 'Get in touch with Ashish Singh Baghel — cloud architecture, DevOps, or speaking enquiries.',
+      }}
+    >
+      <section className="py-16 sm:py-24 text-center max-w-xl mx-auto">
+        <h1 className="text-4xl sm:text-5xl font-bold mb-3">Get in touch</h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-10">
+          Open to cloud architecture discussions, DevOps consulting, or speaking invitations.
+        </p>
+
+        {status === 'success' ? (
+          <div className="rounded-xl border border-green-100 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-8 text-center">
+            <svg className="w-12 h-12 text-green-500 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <h2 className="text-xl font-semibold mb-2">Message sent!</h2>
+            <p className="text-gray-500 dark:text-gray-400 text-sm">Thanks for reaching out. I&apos;ll get back to you soon.</p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-5 text-left">
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium mb-1.5 text-gray-700 dark:text-gray-300">
+                Name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                required
+                value={form.name}
+                onChange={handleChange}
+                placeholder="Your name"
+                className="w-full px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium mb-1.5 text-gray-700 dark:text-gray-300">
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                value={form.email}
+                onChange={handleChange}
+                placeholder="you@example.com"
+                className="w-full px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="message" className="block text-sm font-medium mb-1.5 text-gray-700 dark:text-gray-300">
+                Message
+              </label>
+              <textarea
+                id="message"
+                name="message"
+                rows={5}
+                required
+                value={form.message}
+                onChange={handleChange}
+                placeholder="What's on your mind?"
+                className="w-full px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              />
+            </div>
+
+            {status === 'error' && (
+              <p className="text-sm text-red-600 dark:text-red-400">Something went wrong. Please try again or email me directly.</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="w-full py-2.5 rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-60 text-white text-sm font-medium transition-colors"
+            >
+              {status === 'submitting' ? 'Sending…' : 'Send message'}
+            </button>
+          </form>
+        )}
+
+        {/* Alternative contact */}
+        <div className="mt-10 pt-8 border-t border-gray-100 dark:border-gray-800">
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">Or reach me directly on</p>
+          <div className="flex justify-center gap-4">
+            <a href={config.social.linkedin} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">LinkedIn</a>
+            <a href={config.social.twitter} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 dark:text-blue-400 hover:underline">X / Twitter</a>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -7,6 +7,7 @@ const staticRoutes = [
   { path: '/blog', priority: '0.9', changefreq: 'weekly' },
   { path: '/videos', priority: '0.7', changefreq: 'weekly' },
   { path: '/speaking', priority: '0.7', changefreq: 'monthly' },
+  { path: '/contact', priority: '0.6', changefreq: 'yearly' },
 ];
 
 function generateSitemap(posts) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,6 +3,10 @@
 @tailwind utilities;
 
 @layer base {
+    html {
+        scroll-padding-top: 5rem;
+    }
+
     body {
         @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
         @apply min-h-screen;


### PR DESCRIPTION
## Summary

### Reading time
- Calculated from word count (code blocks excluded, 200 WPM)
- Shown on blog listing cards alongside the date
- Also shown in the blog post header

### Table of contents
- Auto-generated from H2/H3 headings in each post's MDX content
- Only shown on posts with 3 or more headings
- **Desktop (xl+):** sticky sidebar on the right, scrollable if long
- **Mobile:** collapsible `<details>` section above the article

### Social share buttons
- LinkedIn share, X/Twitter share, and copy-link button at the bottom of every post
- Copy-link shows a "Copied!" confirmation for 2 seconds

### Contact page (`/contact`)
- Added to main nav and sitemap
- Form with Name, Email, Message fields
- Posts to Formspree when `NEXT_PUBLIC_FORMSPREE_ENDPOINT` is configured
- Falls back to `mailto:` if env var is not set

## Setting up the contact form (Formspree)

1. Sign up free at [formspree.io](https://formspree.io)
2. Create a new form → copy the endpoint URL (e.g. `https://formspree.io/f/abcd1234`)
3. Add to Vercel: **Settings → Environment Variables → `NEXT_PUBLIC_FORMSPREE_ENDPOINT`**
4. Redeploy — the form will start sending submissions to your email

Without the env var the form still works via `mailto:` fallback.

## Test plan
- [ ] Visit `/blog` — cards show "X min read" next to the date
- [ ] Open a long blog post — TOC sidebar visible on desktop, collapsible on mobile
- [ ] Click a TOC link — jumps to the correct heading
- [ ] Click LinkedIn / X share — opens correct share dialog
- [ ] Click copy link — URL copied and "Copied!" shown briefly
- [ ] Visit `/contact` — form submits successfully (after Formspree setup)

https://claude.ai/code/session_01DUbdRnLfwF6aEcGrxTxFZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUbdRnLfwF6aEcGrxTxFZX)_