### PR TITLE
Fix dark/light theme across card, blog post, homepage, and speaking pages

### DIFF
--- a/components/card/card.js
+++ b/components/card/card.js
@@ -4,12 +4,12 @@ import Date from '../../components/date';
 export default function Card(props) {
   return (
     <Link href={`/blog/${props.id}`} className="block min-w-0 group">
-      <div className="rounded-md border dark:border-gray-700 dark:bg-gray-800 p-6 hover:shadow-xl transition-shadow h-full flex flex-col">
+      <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 hover:shadow-xl transition-shadow h-full flex flex-col">
         <h3 className="text-xl sm:text-2xl font-bold leading-snug tracking-tight mb-2 truncate group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
           {props?.title || 'Untitled'}
         </h3>
 
-        <div className="flex items-center gap-2 text-sm mb-3 text-gray-500">
+        <div className="flex items-center gap-2 text-sm mb-3 text-gray-500 dark:text-gray-400">
           <Date dateString={props.date} />
           {props.readingTime && (
             <>

--- a/components/sections/Header.js
+++ b/components/sections/Header.js
@@ -32,19 +32,21 @@ const Header = () => {
     if (!mounted) return <div className="w-5 h-5" />;
     const currentTheme = theme === 'system' ? systemTheme : theme;
     return currentTheme === 'dark' ? (
-      <SunIcon
-        className="w-5 h-5 cursor-pointer text-gray-400 hover:text-yellow-400 transition-colors"
-        role="button"
+      <button
+        className="select-none p-1 text-gray-400 hover:text-yellow-400 transition-colors"
         aria-label="Switch to light mode"
         onClick={() => setTheme('light')}
-      />
+      >
+        <SunIcon className="w-5 h-5" />
+      </button>
     ) : (
-      <MoonIcon
-        className="w-5 h-5 cursor-pointer text-gray-400 hover:text-blue-600 transition-colors"
-        role="button"
+      <button
+        className="select-none p-1 text-gray-400 hover:text-blue-600 transition-colors"
         aria-label="Switch to dark mode"
         onClick={() => setTheme('dark')}
-      />
+      >
+        <MoonIcon className="w-5 h-5" />
+      </button>
     );
   };
 
@@ -74,7 +76,7 @@ const Header = () => {
           {renderThemeChanger()}
           {/* Hamburger — mobile only */}
           <button
-            className="sm:hidden p-1 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+            className="sm:hidden select-none p-1 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
             onClick={() => setMobileOpen((o) => !o)}
             aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
           >

--- a/pages/blog/[id].js
+++ b/pages/blog/[id].js
@@ -77,7 +77,7 @@ function ShareButtons({ title, id }) {
           href={twitterUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-black hover:bg-gray-800 text-white transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-black dark:bg-gray-900 hover:bg-gray-800 dark:hover:bg-gray-700 text-white transition-colors"
         >
           <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />

--- a/pages/index.js
+++ b/pages/index.js
@@ -143,7 +143,7 @@ export default function Home({ allPostsData }) {
         </p>
         <Link
           href="/speaking"
-          className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-white text-blue-600 font-medium hover:bg-blue-50 transition-colors"
+          className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-white dark:bg-white/90 text-blue-600 font-medium hover:bg-blue-50 dark:hover:bg-white transition-colors"
         >
           View my talks <ArrowRightIcon className="w-4 h-4" />
         </Link>

--- a/pages/speaking.js
+++ b/pages/speaking.js
@@ -141,7 +141,7 @@ export default function Speaking() {
             href={config.social.linkedin}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-white text-blue-600 font-medium hover:bg-blue-50 transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-white dark:bg-white/90 text-blue-600 font-medium hover:bg-blue-50 dark:hover:bg-white transition-colors"
           >
             Get in touch on LinkedIn
           </a>


### PR DESCRIPTION
## Summary

- **Blog card (`components/card/card.js`)**: Added `border-gray-200 bg-white` for light mode — cards were transparent/borderless in light mode since only `dark:` variants existed. Also added `dark:text-gray-400` to the date/reading-time row so it's readable in dark mode.
- **Homepage (`pages/index.js`) & Speaking page (`pages/speaking.js`)**: CTA buttons inside the blue gradient sections now have `dark:bg-white/90 dark:hover:bg-white` — the pure `bg-white` was visually correct in light mode but lacked explicit dark mode treatment.
- **Blog post (`pages/blog/[id].js`)**: X/Twitter share button now uses `dark:bg-gray-900 dark:hover:bg-gray-700` — solid black blended into the dark background in dark mode.

## Test plan

- [ ] Toggle between light and dark mode on the homepage — blog cards should show a visible border and white background in light mode
- [ ] Check the Speaking teaser CTA on the homepage and the invite CTA on `/speaking` in both themes — button should remain clearly visible
- [ ] Open any blog post and toggle themes — X/Twitter share button should be distinguishable from the dark background in dark mode
- [ ] Date and reading time on blog cards should be readable in both themes

https://claude.ai/code/session_01DUbdRnLfwF6aEcGrxTxFZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUbdRnLfwF6aEcGrxTxFZX)_